### PR TITLE
fix: Discord notification sounds

### DIFF
--- a/debian/patches/discord.patch
+++ b/debian/patches/discord.patch
@@ -1,0 +1,18 @@
+Index: pipewire/src/daemon/pipewire-pulse.conf.in
+===================================================================
+--- pipewire.orig/src/daemon/pipewire-pulse.conf.in
++++ pipewire/src/daemon/pipewire-pulse.conf.in
+@@ -143,4 +143,13 @@ pulse.rules = [
+             }
+         }
+     }
++    {
++        # Discord notification sounds fix
++        matches = [ { application.process.binary = "Discord" } ]
++        actions = {
++            update-props = {
++                pulse.min.quantum      = 1024/48000     # 21ms
++            }
++        }
++    }
+ ]

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 Don-t-automatically-start-pipewire-for-root-logins.patch
 Don-t-build_same_binary_twice.patch
 alsa-type-pulse.patch
+discord.patch


### PR DESCRIPTION
Found from https://wiki.archlinux.org/title/PipeWire#No_notification_sounds_from_Discord

Was able to replicate and this did fix it for me.