### PR TITLE
Update meson.build

### DIFF
--- a/src/modules/meson.build
+++ b/src/modules/meson.build
@@ -139,7 +139,7 @@ pipewire_module_echo_cancel_sources = [
 pipewire_module_combine_stream = shared_library('pipewire-module-combine-stream',
   [ 'module-combine-stream.c' ],
   include_directories : [configinc],
-  install : false,
+  install : true,
   install_dir : modules_install_dir,
   install_rpath: modules_install_dir,
   dependencies : [spa_dep, dl_lib, pipewire_dep],


### PR DESCRIPTION
This needs to be set to true in order for the combine-sink/combine-stream function to work at all. Vital for creators to be able to function on a workflow. This is inline with https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/fba7083f8ceb210c7c20aceafeb5c9a8767cf705